### PR TITLE
Support modern x86 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blurdroid"
-version = "0.1.4"
+version = "0.1.5"
 description = "Bluetooth lib for Rust using Android's bluedroid"
 readme = "README.md"
 authors = ["Attila Dusnoki <adusnoki@inf.u-szeged.hu>"]

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,7 @@ fn android_main() {
         "arm64-v8a"
     } else if target.contains("arm") {
         "armeabi"
-    } else if target.contains("x86") {
+    } else if target.contains("x86") || target.contains("i686") {
         "x86"
     } else {
         panic!("Invalid target architecture {}", target);


### PR DESCRIPTION
The required target is i686-linux-android now. This PR also includes changes that allowed me to build blurdroid when using a cargo override, and fixes #2.